### PR TITLE
as per SYSDESK-1720, trying to add some security to ipmi

### DIFF
--- a/lib/facter/ipmi_firmware.rb
+++ b/lib/facter/ipmi_firmware.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+#
+# IPMI firmware fact(s)
+#
+# these are basic facts from ipmitool mc info
+
+def parse_ipmitool_output ipmitool_output
+  ipmitool_output.each_line do |line|
+    case line.strip
+    when /^Firmware Revision\s*:\s+(\S.*)/
+      add_ipmi_fact("firmware_version", $1)
+    end
+  end
+end
+
+def add_ipmi_fact name, value
+  fact_names = []
+  # default channels: supermicro = 1, hp = 2
+  fact_names.push("ipmi_#{name}")
+  fact_names.each do |name|
+    Facter.add(name) do
+      confine :kernel => "Linux"
+      setcode do
+        value
+      end
+    end
+  end
+end
+
+if Facter::Util::Resolution.which('ipmitool')
+  ipmitool_output = Facter::Util::Resolution.exec("timeout 5 ipmitool mc info 2>&1")
+  if ipmitool_output
+    parse_ipmitool_output ipmitool_output
+  end
+end
+

--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -1,0 +1,17 @@
+# == Defined resource type: ipmi::auth
+# title should be one of: Callback, User, Operator, Admin
+# the preferred auth type available atm is MD5, marginally better than MD2 or plain
+
+define ipmi::auth (
+  $auth_type = 'MD5',
+){
+  require ::ipmi
+
+  validate_re($title, '^Callback$|^User$|^Operator$|^Admin$', 'Auth title should be one of: Callback|User|Operator|Admin')
+  validate_re($auth_type, '^NONE$|^MD2$|^MD5$|^PASSWORD$', 'Auth type should be one of: NONE|MD2|MD5|PASSWORD')
+
+  exec { "ipmi_set_auth_${title}":
+    command => "/usr/bin/ipmitool lan set 1 auth ${title} ${auth_type}",
+    onlyif  => "/usr/bin/test \"$(ipmitool lan print | grep -A 4 'Auth Type Enable' | grep \"${title}\" sed -e 's/.* : //g')\" != \"${auth_type}\"",
+  }
+}

--- a/manifests/ciphers.pp
+++ b/manifests/ciphers.pp
@@ -1,0 +1,45 @@
+# == Defined resource type: ipmi::ciphers
+#
+# the ciphers list refers to the ciphers that are useable by admin
+# ipmitool lan print will list which are available, but all 14 
+# should be represented in the ciphers_list string - they should be marked
+# 'X' to show they are excluded
+#
+# RMCP+ Cipher Suites : 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+#
+# the below command will display the various ciphers:
+#
+# ipmitool channel getciphers ipmi 1
+# ID   IANA    Auth Alg        Integrity Alg   Confidentiality Alg
+# 0    N/A     none            none            none
+# 1    N/A     hmac_sha1       none            none
+# 2    N/A     hmac_sha1       hmac_sha1_96    none
+# 3    N/A     hmac_sha1       hmac_sha1_96    aes_cbc_128
+# 4    N/A     hmac_sha1       hmac_sha1_96    xrc4_128
+# 5    N/A     hmac_sha1       hmac_sha1_96    xrc4_40
+# 6    N/A     hmac_md5        none            none
+# 7    N/A     hmac_md5        hmac_md5_128    none
+# 8    N/A     hmac_md5        hmac_md5_128    aes_cbc_128
+# 9    N/A     hmac_md5        hmac_md5_128    xrc4_128
+# 10   N/A     hmac_md5        hmac_md5_128    xrc4_40
+# 11   N/A     hmac_md5        md5_128         none
+# 12   N/A     hmac_md5        md5_128         aes_cbc_128
+# 13   N/A     hmac_md5        md5_128         xrc4_128
+# 14   N/A     hmac_md5        md5_128         xrc4_40
+# 
+# the default is to allow only those required by SOL or any 128/aes128
+# 
+# Note: this is not required for HP
+
+define ipmi::ciphers (
+  $ciphers_list = 'XXXaXXXXaXXXaXX',
+){
+  require ::ipmi
+
+  validate_string($ciphers_list)
+
+  exec { "ipmi_set_ciphers":
+    command => "/usr/bin/ipmitool lan set 1 cipher_privs ${ciphers_list}",
+    onlyif  => "/usr/bin/test \"$(ipmitool lan print | grep 'Cipher Suite Priv Max' | sed -e 's/.* : //g')\" != \"${ciphers_list}\"",
+  }
+}


### PR DESCRIPTION
Well not really - but it's a couple of things to at least make ipmi marginally more secure:
 - adding an ipmi firmware version fact
 - introduce define for auth types to set encryption levels
 - introduce define for ciphers
 - the default ciphers string removes weaker ciphers and disables the '0' cipher which allows for admin access via a dummy password